### PR TITLE
Fixed removeUnreachableNodes()

### DIFF
--- a/src/fsm/Fsm.cpp
+++ b/src/fsm/Fsm.cpp
@@ -1595,11 +1595,17 @@ bool Fsm::removeUnreachableNodes(std::vector<shared_ptr<FsmNode>>& unreachableNo
     // Mark all reachable nodes as 'visited'
     accept(v);
     
+    // When removing nodes from the FSM, the node ids of all remaining nodes
+    // have to be adapted, in order to match the index in the list of nodes.
+    int subtractFromId = 0;
     for ( auto n : nodes ) {
         if ( not n->hasBeenVisited() ) {
             unreachableNodes.push_back(n);
+            presentationLayer->removeState2String(n->getId() - subtractFromId);
+            ++subtractFromId;
         }
         else {
+            n->setId(n->getId() - subtractFromId);
             newNodes.push_back(n);
         }
     }

--- a/src/fsm/FsmNode.h
+++ b/src/fsm/FsmNode.h
@@ -63,7 +63,8 @@ public:
     
     
     std::vector<std::shared_ptr<FsmTransition> >& getTransitions();
-	int getId() const;
+    int getId() const;
+    void setId(const int id) { this->id = id; }
 	std::string getName() const;
 	bool hasBeenVisited() const;
 	void setVisited();

--- a/src/interface/FsmPresentationLayer.h
+++ b/src/interface/FsmPresentationLayer.h
@@ -62,6 +62,11 @@ public:
                          const std::string & outputs,
                          const std::string & states);
 
+    void removeState2String(const int index)
+    {
+        state2String.erase(state2String.begin() + index);
+    }
+
 	/**
 	 * Getter for a particular input name
 	 * @param id The id of the input


### PR DESCRIPTION
Fixed bug where remaining node IDs have not been updated after removing nodes from an FSM.