### PR TITLE
Fixed wrong lookup of node class ids in when creating a FSM from an OFSM table

### DIFF
--- a/src/fsm/OFSMTable.cpp
+++ b/src/fsm/OFSMTable.cpp
@@ -278,7 +278,7 @@ Fsm OFSMTable::toFsm(const string & name) const
 	{
 		/*The node id of the new FsmState corresponds to the
 		class id we are currently processing.*/
-		int classId = srcNode->getId();
+        int classId = s2c.at(srcNode->getId());
 
 		/*Find the first OFSMTableRow where the associated original FsmState
 		belongs to class classId. Since other rows associated with
@@ -309,8 +309,8 @@ Fsm OFSMTable::toFsm(const string & name) const
 					/*Find the new FsmNode in the minimised FSM
 					which has tgtClassId as node id*/
 					for (shared_ptr<FsmNode> tgtNode : nodeLst)
-					{
-						if (tgtNode->getId() == tgtClassId)
+                    {
+                        if (s2c.at(tgtNode->getId()) == tgtClassId)
 						{
 							/*Create the transition with label x/y
 							and target node tgtNode*/


### PR DESCRIPTION
There is no correlation between class ids and node ids. The class id is an arbitrary number, created in the OFSM table algorithm (see OFSMTable.cpp, [line 129 ](https://github.com/agbs-uni-bremen/fsmlib-cpp/blob/master/src/fsm/OFSMTable.cpp#L129)):

```
shared_ptr<OFSMTable> OFSMTable::next()
{
	if (tblId == 0)
	{
		return nextAfterZero();
	}

	shared_ptr<OFSMTable> next = make_shared<OFSMTable>(numStates, maxInput, maxOutput, rows, presentationLayer);
	next->tblId = tblId + 1;

	int thisClass = 0;
        // Important line containing creation of arbitrary class id:
	int thisNewClassId = maxClassId() + 1;
	shared_ptr<OFSMTableRow> refRow;
	shared_ptr<OFSMTableRow> newClassRefRow;
	S2CMap newS2C = next->getS2C();
	bool haveNewClasses = false;

	do
	{
           //...
```
Therefore, the lookup for class ids when creating a FSM from a given OFSM table has to be fixed.