### PR TITLE
Fixed representation of state names for FSMs that have been transformed to observable machines.

### DIFF
--- a/src/fsm/Fsm.cpp
+++ b/src/fsm/Fsm.cpp
@@ -601,12 +601,20 @@ Fsm Fsm::transformToObservableFSM() const
     unordered_set<shared_ptr<FsmNode>> theLabel;
     
     theLabel.insert(getInitialState());
+
+    vector<string> obsState2String;
+    shared_ptr<FsmPresentationLayer> obsPl =
+    make_shared<FsmPresentationLayer>(presentationLayer->getIn2String(),
+                                      presentationLayer->getOut2String(),
+                                      obsState2String);
     
     int id = 0;
-    shared_ptr<FsmNode> q0 = make_shared<FsmNode>(id ++, labelString(theLabel), presentationLayer);
+    string nodeName = labelString(theLabel);
+    shared_ptr<FsmNode> q0 = make_shared<FsmNode>(id ++, nodeName, obsPl);
     nodeLst.push_back(q0);
     bfsLst.push_back(q0);
     node2Label[q0] = theLabel;
+    obsPl->addState2String(nodeName);
     
     while (!bfsLst.empty())
     {
@@ -620,7 +628,7 @@ Fsm Fsm::transformToObservableFSM() const
             for (int y = 0; y <= maxOutput; ++ y)
             {
                 shared_ptr<FsmLabel> lbl =
-                make_shared<FsmLabel>(x, y, presentationLayer);
+                make_shared<FsmLabel>(x, y, obsPl);
                 theLabel.clear();
                 
                 for (shared_ptr<FsmNode> n : node2Label.at(q))
@@ -654,10 +662,12 @@ Fsm Fsm::transformToObservableFSM() const
                     /*We need to create a new node*/
                     if (tgtNode == nullptr)
                     {
-                        tgtNode = make_shared<FsmNode>(id ++, labelString(theLabel), presentationLayer);
+                        nodeName = labelString(theLabel);
+                        tgtNode = make_shared<FsmNode>(id ++, nodeName, obsPl);
                         nodeLst.push_back(tgtNode);
                         bfsLst.push_back(tgtNode);
                         node2Label[tgtNode] = theLabel;
+                        obsPl->addState2String(nodeName);
                     }
                     
                     /*Create the transition from q to tgtNode*/
@@ -667,7 +677,7 @@ Fsm Fsm::transformToObservableFSM() const
             }
         }
     }
-    return Fsm(name + "_O", maxInput, maxOutput, nodeLst, presentationLayer);
+    return Fsm(name + "_O", maxInput, maxOutput, nodeLst, obsPl);
 }
 
 bool Fsm::isObservable() const

--- a/src/interface/FsmPresentationLayer.cpp
+++ b/src/interface/FsmPresentationLayer.cpp
@@ -51,6 +51,19 @@ FsmPresentationLayer::FsmPresentationLayer(const std::string& inputs, const std:
 	}
 }
 
+void FsmPresentationLayer::addState2String(std::string name)
+{
+    state2String.push_back(name);
+}
+
+void FsmPresentationLayer::removeState2String(const int index)
+{
+    if (index >= 0 && state2String.size() > static_cast<size_t>(index))
+    {
+        state2String.erase(state2String.begin() + index);
+    }
+}
+
 std::string FsmPresentationLayer::getInId(const unsigned int id) const
 {
 	if (id >= in2String.size())

--- a/src/interface/FsmPresentationLayer.h
+++ b/src/interface/FsmPresentationLayer.h
@@ -62,12 +62,8 @@ public:
                          const std::string & outputs,
                          const std::string & states);
 
-    void removeState2String(const int index)
-    {
-        if ( state2String.size() > index) {
-            state2String.erase(state2String.begin() + index);
-        }
-    }
+    void addState2String(std::string name);
+    void removeState2String(const int index);
 
 	/**
 	 * Getter for a particular input name


### PR DESCRIPTION
When converting a non-observable FSM to an observable FSM, the presentation layer is currently not being updated. Until now, only the node's "names" (aka prefixes) contain the corresponding node names from the original (non-observable) FSM.

This pull requests creates a new presentation layer (containing the new node names) for the observable FSM.