### PR TITLE
Breaking circular referencing that causes memory leaks

### DIFF
--- a/src/fsm/FsmTransition.cpp
+++ b/src/fsm/FsmTransition.cpp
@@ -30,7 +30,7 @@ FsmTransition::FsmTransition(const shared_ptr<FsmNode>  source,
 
 shared_ptr<FsmNode> FsmTransition::getSource()
 {
-	return source;
+    return source.lock();
 }
 
 void FsmTransition::setSource(shared_ptr<FsmNode> src) {
@@ -39,7 +39,7 @@ void FsmTransition::setSource(shared_ptr<FsmNode> src) {
 
 shared_ptr<FsmNode> FsmTransition::getTarget()
 {
-	return target;
+    return target.lock();
 }
 
 void FsmTransition::setTarget(shared_ptr<FsmNode> tgt) {

--- a/src/fsm/FsmTransition.h
+++ b/src/fsm/FsmTransition.h
@@ -19,12 +19,12 @@ private:
 	/**
 	 *The node from which the transition comes
 	 */
-	std::shared_ptr<FsmNode> source;
+    std::weak_ptr<FsmNode> source;
 
 	/**
 	 * The node where the transition go
 	 */
-	std::shared_ptr<FsmNode> target;
+    std::weak_ptr<FsmNode> target;
 
 	/**
 	 * The label of this transition


### PR DESCRIPTION
Breaking circular referencing that causes massive memory leaks in a gigagabyte scale when testing a large amount (>10,000) of FSMs.